### PR TITLE
Bumped Version numbers to stable / latest as of July 2021

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,12 @@ ARG DEBIAN_VERSION=stretch-slim
 
 ##### Building stage #####
 FROM debian:${DEBIAN_VERSION} as builder
-MAINTAINER Tareq Alqutami <tareqaziz2010@gmail.com>
+LABEL author="github/brianmangan"
 
 # Versions of nginx, rtmp-module and ffmpeg 
-ARG  NGINX_VERSION=1.17.5
+ARG  NGINX_VERSION=1.20.1
 ARG  NGINX_RTMP_MODULE_VERSION=1.2.1
-ARG  FFMPEG_VERSION=4.2.1
+ARG  FFMPEG_VERSION=4.4
 
 # Install dependencies
 RUN apt-get update && \

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -1,13 +1,13 @@
-ARG ALPINE_VERSION=3.11
+ARG ALPINE_VERSION=3.14.0
 
 ##### Building stage #####
 FROM alpine:${ALPINE_VERSION} as builder
-MAINTAINER Tareq Alqutami <tareqaziz2010@gmail.com>
+MAINTAINER github/brianmangan
 
 # Versions of nginx, rtmp-module and ffmpeg 
-ARG  NGINX_VERSION=1.17.5
+ARG  NGINX_VERSION=1.20.1
 ARG  NGINX_RTMP_MODULE_VERSION=1.2.1
-ARG  FFMPEG_VERSION=4.2.1
+ARG  FFMPEG_VERSION=4.4
 
 # Install dependencies
 RUN apk update	&& \

--- a/Dockerfile-nvenc
+++ b/Dockerfile-nvenc
@@ -4,9 +4,9 @@ MAINTAINER Kieran Harkin <kieran+git@harkin.me>
 
 # Versions of nginx, rtmp-module and ffmpeg 
 ENV  TZ=Europe/Dublin
-ARG  NGINX_VERSION=1.19.4
+ARG  NGINX_VERSION=1.20.1
 ARG  NGINX_RTMP_MODULE_VERSION=1.2.1
-ARG  FFMPEG_VERSION=4.3.1
+ARG  FFMPEG_VERSION=4.4
 
 # Install dependencies
 RUN apt update && \

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 **Docker image for video streaming server that supports RTMP, HLS, and DASH streams.**
 
-[![Docker Automated build](https://img.shields.io/docker/cloud/automated/alqutami/rtmp-hls.svg)](https://hub.docker.com/r/alqutami/rtmp-hls/builds/)
-[![Build Status](https://img.shields.io/docker/cloud/build/alqutami/rtmp-hls.svg)](https://hub.docker.com/r/alqutami/rtmp-hls)
+[![Docker Automated build](https://img.shields.io/docker/cloud/automated/brianmangan/rtmp-hls.svg)](https://hub.docker.com/r/brianmangan/rtmp-hls/builds/)
+[![Build Status](https://img.shields.io/docker/cloud/build/brianmangan/rtmp-hls.svg)](https://hub.docker.com/r/brianmangan/rtmp-hls)
 
 ## Description
 
@@ -23,9 +23,9 @@ All modules are built from source on Debian and Alpine Linux base images.
  * Available web video players (based on [video.js](https://videojs.com/) and [hls.js](https://github.com/video-dev/hls.js/)) at `/usr/local/nginx/html/players`. 
 
 Current Image is built using:
- * Nginx 1.17.5 (compiled from source)
+ * Nginx 1.20.1 (compiled from source)
  * Nginx-rtmp-module 1.2.1 (compiled from source)
- * FFmpeg 4.2.1 (compiled from source)
+ * FFmpeg 4.4 (compiled from source)
 
 This image was inspired by similar docker images from [tiangolo](https://hub.docker.com/r/tiangolo/nginx-rtmp/) and [alfg](https://hub.docker.com/r/alfg/nginx-rtmp/). It has small build size, adds support for HTTP-based streams and adaptive streaming using FFmpeg.
 
@@ -33,17 +33,17 @@ This image was inspired by similar docker images from [tiangolo](https://hub.doc
 
 ### To run the server
 ```
-docker run -d -p 1935:1935 -p 8080:8080 alqutami/rtmp-hls
+docker run -d -p 1935:1935 -p 8080:8080 brianmangan/rtmp-hls
 ```
 
 For Alpine-based Image use:
 ```
-docker run -d -p 1935:1935 -p 8080:8080 alqutami/rtmp-hls:latest-alpine
+docker run -d -p 1935:1935 -p 8080:8080 brianmangan/rtmp-hls:latest-alpine
 ```
 
 To run with custom conf file:
 ```
-docker run -d -p 1935:1935 -p 8080:8080 -v custom.conf:/etc/nginx/nginx.conf alqutami/rtmp-hls
+docker run -d -p 1935:1935 -p 8080:8080 -v custom.conf:/etc/nginx/nginx.conf brianmangan/rtmp-hls
 ```
 where `custom.conf` is the new conf file for Nginx.
 
@@ -84,7 +84,7 @@ The provided demo players assume the stream-key is called `test` and the player 
 	* These web players are hardcoded to play stream key "test" at localhost.
 	* To change the stream source for these players. Download the html files and modify the `src` attribute in the video tag in the html file. You can then mount the modified files to the container as follows:
 		```
-		docker run -d -p 1935:1935 -p 8080:8080 -v custom_players:/usr/local/nginx/html/players alqutami/rtmp-hls
+		docker run -d -p 1935:1935 -p 8080:8080 -v custom_players:/usr/local/nginx/html/players brianmangan/rtmp-hls
 		```
 		where `custom_players` is the directory holding the modified html files.
 
@@ -92,6 +92,6 @@ The provided demo players assume the stream-key is called `test` and the player 
 Released under MIT license.
 
 ## More info
- * **GitHub repo**: <https://github.com/TareqAlqutami/rtmp-hls-server.git>
+ * **GitHub repo**: <https://github.com/Tareqbrianmangan/rtmp-hls-server.git>
 
- * **Docker Hub image**: <https://hub.docker.com/r/alqutami/rtmp-hls>
+ * **Docker Hub image**: <https://hub.docker.com/r/brianmangan/rtmp-hls>


### PR DESCRIPTION
bumped versions: 

Alpine 3.14.0
Nginx 1.20.1
FFmpeg 4.4 
